### PR TITLE
Update balanceValidator.rs

### DIFF
--- a/programs/memetree/src/validator/balanceValidator.rs
+++ b/programs/memetree/src/validator/balanceValidator.rs
@@ -3,9 +3,11 @@ use anchor_lang::prelude::*;
 
 use crate::{constants::TREASURY_FEE, errors::FundError};
 
-pub fn balanceValidator(wallet: AccountInfo) {
-    msg!("Before Lamport is ==========> {}", wallet.get_lamports());
+pub fn balance_validator(wallet: AccountInfo) -> Result<()> {
+    msg!("Current wallet balance in lamports: {}", wallet.get_lamports());
     if wallet.get_lamports() < TREASURY_FEE as u64 {
-        FundError::InsufficiencyError;
+        return Err(FundError::InsufficiencyError.into());
     }
+    Ok(())
 }
+


### PR DESCRIPTION
This version now returns Result<()>, which allows you to use ? to propagate errors and handle them as expected in the caller function.